### PR TITLE
Fixed typo in README in showErrors part

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ $('.dropify').dropify();
 ```
 
 
-* __showErrors:__  You can hide errors if you add the attr __data-show-loader="false"__. Default: true.
+* __showErrors:__  You can hide errors if you add the attr __data-show-errors="false"__. Default: true.
 
 ```html
 <input type="file" class="dropify" data-show-errors="true" />


### PR DESCRIPTION
Fixed typo in **showErrors** part of README.md file. Earlier it was **data-show-loader="false"** in the description fixed it to **data-show-errors="false"**