### PR TITLE
Change getFileType function to fix issue #98

### DIFF
--- a/src/js/dropify.js
+++ b/src/js/dropify.js
@@ -384,7 +384,7 @@ Dropify.prototype.isTouchDevice = function()
  */
 Dropify.prototype.getFileType = function()
 {
-    return this.file.name.split('.').pop().toLowerCase();
+    return this.file.name.split('.').pop().split(/\#|\?/).shift().toLowerCase();
 };
 
 /**


### PR DESCRIPTION
Fix getFileType function to extract file extension in a signed url.

refs #98 